### PR TITLE
Utility methods for type-specific configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ Get value with config name:
 ``` php
 LaravelConfig::get('key');
 ```
+
+Get value as boolean with config name:
+
+``` php
+LaravelConfig::getValueAsBoolean('key');
+```
+
+Get value as integer with config name:
+
+``` php
+LaravelConfig::getValueAsInt('key');
+```
+Get value as decoded json with config name:
+
+``` php
+LaravelConfig::getValueAsDecodeJson('key');
+```
+Get value as date with config name:
+
+``` php
+LaravelConfig::getValueAsDate('key');
+```
+
 Set value with config name and value:
 
 ``` php

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "require": {
         "php": "^7.4|^8.0|^8.1|^8.2",
         "illuminate/support": "^8.49|^9.0|^10.0",
-        "laravel/legacy-factories": "^1.0"
+        "laravel/legacy-factories": "^1.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "orchestra/testbench": "^6.13|^7.0|^8.0",

--- a/src/LaravelConfig.php
+++ b/src/LaravelConfig.php
@@ -2,6 +2,7 @@
 
 namespace TarfinLabs\LaravelConfig;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use TarfinLabs\LaravelConfig\Config\Config;
 use TarfinLabs\LaravelConfig\Config\ConfigItem;
@@ -164,5 +165,97 @@ class LaravelConfig
         $config->tags = $configItem->tags;
 
         return $config;
+    }
+
+    /**
+     * Retrieves the value of the specified configuration key as a boolean.
+     *
+     * @param string $name
+     * @param $default
+     * @return bool|null
+     */
+    public function getValueAsBoolean(string $name, $default = null): ?bool
+    {
+        $value = $this->get($name, $default);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return (bool) $value;
+    }
+
+    /**
+     * Retrieves the value of the specified configuration key as an integer.
+     *
+     * @param string $name The specified configuration key
+     * @param mixed $default The default value (optional)
+     * @return int|null The integer value of the specified configuration key or null
+     */
+    public function getValueAsInt(string $name, $default = null): ?int
+    {
+        $value = $this->get($name, $default);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * Retrieves the value of the specified configuration key and decodes it from JSON to an array or an object.
+     *
+     * @param string $name The specified configuration key
+     * @param mixed $default The default value (optional)
+     * @param bool $associative When true, returned objects will be converted into associative arrays.
+     * @param int $depth User specified recursion depth.
+     * @return array The decoded array value of the specified configuration key
+     */
+    public function getValueAsDecodeJson(string $name, $default = [], ?bool $associative = true, int $depth = 512): array
+    {
+        $value = $this->get($name, $default);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_array($value)) {
+            return $value;
+        }
+
+        $decodedValue = json_decode($value, $associative, $depth);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $decodedValue;
+        }
+
+        return $default;
+    }
+
+    /**
+     * Retrieves the value of the specified configuration key and converts it to a Carbon Date instance.
+     *
+     * @param string $name The specified configuration key
+     * @param mixed $default The default value (optional)
+     * @return Carbon|null The Carbon Date instance of the specified configuration key, or null if conversion fails
+     */
+    public function getValueAsDate(string $name, $default = null): ?Carbon
+    {
+        $value = $this->get($name, $default);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        return Carbon::createFromFormat('Y-m-d H:i', $value);
     }
 }

--- a/src/LaravelConfig.php
+++ b/src/LaravelConfig.php
@@ -12,7 +12,7 @@ class LaravelConfig
     /**
      * Get config by given name.
      *
-     * @param  string  $name
+     * @param  string $name
      * @param  $default
      * @return mixed
      */
@@ -170,7 +170,7 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key as a boolean.
      *
-     * @param  string $name
+     * @param  string  $name
      * @param  $default
      * @return bool|null
      */
@@ -192,8 +192,8 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key as an integer.
      *
-     * @param  string $name
-     * @param  mixed $default
+     * @param  string  $name
+     * @param  mixed  $default
      * @return int|null
      */
     public function getValueAsInt(string $name, $default = null): ?int
@@ -214,10 +214,10 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key and decodes it from JSON to an array or an object.
      *
-     * @param  string $name
-     * @param  mixed $default
-     * @param  bool $associative
-     * @param  int $depth
+     * @param  string  $name
+     * @param  mixed  $default
+     * @param  bool  $associative
+     * @param  int  $depth
      * @return array
      */
     public function getValueAsDecodeJson(string $name, $default = [], ?bool $associative = true, int $depth = 512): array
@@ -244,8 +244,8 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key and converts it to a Carbon Date instance.
      *
-     * @param  string $name
-     * @param  mixed $default
+     * @param  string  $name
+     * @param  mixed  $default
      * @return Carbon|null
      */
     public function getValueAsDate(string $name, $default = null): ?Carbon

--- a/src/LaravelConfig.php
+++ b/src/LaravelConfig.php
@@ -55,7 +55,7 @@ class LaravelConfig
     }
 
     /**
-     * @param $tags
+     * @param  $tags
      * @return Collection
      */
     public function getByTag($tags): ?Collection
@@ -170,8 +170,8 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key as a boolean.
      *
-     * @param string $name
-     * @param $default
+     * @param  string $name
+     * @param  $default
      * @return bool|null
      */
     public function getValueAsBoolean(string $name, $default = null): ?bool
@@ -192,8 +192,8 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key as an integer.
      *
-     * @param string $name
-     * @param mixed $default
+     * @param  string $name
+     * @param  mixed $default
      * @return int|null
      */
     public function getValueAsInt(string $name, $default = null): ?int
@@ -214,10 +214,10 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key and decodes it from JSON to an array or an object.
      *
-     * @param string $name
-     * @param mixed $default
-     * @param bool $associative
-     * @param int $depth
+     * @param  string $name
+     * @param  mixed $default
+     * @param  bool $associative
+     * @param  int $depth
      * @return array
      */
     public function getValueAsDecodeJson(string $name, $default = [], ?bool $associative = true, int $depth = 512): array
@@ -244,8 +244,8 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key and converts it to a Carbon Date instance.
      *
-     * @param string $name
-     * @param mixed $default
+     * @param  string $name
+     * @param  mixed $default
      * @return Carbon|null
      */
     public function getValueAsDate(string $name, $default = null): ?Carbon

--- a/src/LaravelConfig.php
+++ b/src/LaravelConfig.php
@@ -12,7 +12,7 @@ class LaravelConfig
     /**
      * Get config by given name.
      *
-     * @param  string $name
+     * @param  string  $name
      * @param  $default
      * @return mixed
      */

--- a/src/LaravelConfig.php
+++ b/src/LaravelConfig.php
@@ -192,9 +192,9 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key as an integer.
      *
-     * @param string $name The specified configuration key
-     * @param mixed $default The default value (optional)
-     * @return int|null The integer value of the specified configuration key or null
+     * @param string $name
+     * @param mixed $default
+     * @return int|null
      */
     public function getValueAsInt(string $name, $default = null): ?int
     {
@@ -214,11 +214,11 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key and decodes it from JSON to an array or an object.
      *
-     * @param string $name The specified configuration key
-     * @param mixed $default The default value (optional)
-     * @param bool $associative When true, returned objects will be converted into associative arrays.
-     * @param int $depth User specified recursion depth.
-     * @return array The decoded array value of the specified configuration key
+     * @param string $name
+     * @param mixed $default
+     * @param bool $associative
+     * @param int $depth
+     * @return array
      */
     public function getValueAsDecodeJson(string $name, $default = [], ?bool $associative = true, int $depth = 512): array
     {
@@ -244,9 +244,9 @@ class LaravelConfig
     /**
      * Retrieves the value of the specified configuration key and converts it to a Carbon Date instance.
      *
-     * @param string $name The specified configuration key
-     * @param mixed $default The default value (optional)
-     * @return Carbon|null The Carbon Date instance of the specified configuration key, or null if conversion fails
+     * @param string $name
+     * @param mixed $default
+     * @return Carbon|null
      */
     public function getValueAsDate(string $name, $default = null): ?Carbon
     {

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -192,13 +192,13 @@ class LaravelConfigTest extends TestCase
     public function it_returns_nested_config_parameters(): void
     {
         factory(Config::class)->create([
-            'name'  => 'foo.bar',
-            'val'   => true,
+            'name' => 'foo.bar',
+            'val'  => true,
         ]);
 
         factory(Config::class)->create([
-            'name'  => 'foo.baz',
-            'val'   => false,
+            'name' => 'foo.baz',
+            'val'  => false,
         ]);
 
         $response = $this->laravelConfig->getNested('foo');
@@ -212,13 +212,13 @@ class LaravelConfigTest extends TestCase
     public function it_returns_value_as_boolean(): void
     {
         factory(Config::class)->create([
-            'name'  => 'yunus.was.here',
-            'val'   => "1",
+            'name' => 'yunus.was.here',
+            'val'  => "1",
         ]);
 
         factory(Config::class)->create([
-            'name'  => 'foo.bar',
-            'val'   => "0",
+            'name' => 'foo.bar',
+            'val'  => "0",
         ]);
 
         $this->assertTrue($this->laravelConfig->getValueAsBoolean('yunus.was.here'));
@@ -229,8 +229,8 @@ class LaravelConfigTest extends TestCase
     public function it_returns_value_as_int(): void
     {
         factory(Config::class)->create([
-            'name'  => 'yunus.was.here',
-            'val'   => "123456",
+            'name' => 'yunus.was.here',
+            'val'  => "123456",
         ]);
 
         $this->assertIsInt($this->laravelConfig->getValueAsInt('yunus.was.here'));
@@ -240,8 +240,8 @@ class LaravelConfigTest extends TestCase
     public function it_returns_value_as_decode_json(): void
     {
         factory(Config::class)->create([
-            'name'  => 'yunus.was.here',
-            'val'   => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}'
+            'name' => 'yunus.was.here',
+            'val'  => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}'
         ]);
 
         $response = $this->laravelConfig->getValueAsDecodeJson('yunus.was.here');
@@ -256,8 +256,8 @@ class LaravelConfigTest extends TestCase
     public function it_returns_value_as_date(): void
     {
         factory(Config::class)->create([
-            'name'  => 'yunus.was.here',
-            'val'   => '2024-02-28 17:00'
+            'name' => 'yunus.was.here',
+            'val'  => '2024-02-28 17:00'
         ]);
 
         $response = $this->laravelConfig->getValueAsDate('yunus.was.here');

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -241,7 +241,7 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'yunus.was.here',
-            'val' => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}'
+            'val' => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}',
         ]);
 
         $response = $this->laravelConfig->getValueAsDecodeJson('yunus.was.here');
@@ -257,7 +257,7 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'yunus.was.here',
-            'val' => '2024-02-28 17:00'
+            'val' => '2024-02-28 17:00',
         ]);
 
         $response = $this->laravelConfig->getValueAsDate('yunus.was.here');

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace TarfinLabs\LaravelConfig\Tests;
 
+use Carbon\Carbon;
 use Illuminate\Support\Str;
 use TarfinLabs\LaravelConfig\Config\Config;
 use TarfinLabs\LaravelConfig\Config\ConfigFactory;
@@ -205,5 +206,62 @@ class LaravelConfigTest extends TestCase
         $this->assertEquals(2, $response->count());
         $this->assertEquals('bar', $response->first()->name);
         $this->assertEquals('baz', $response->last()->name);
+    }
+
+    /** @test */
+    public function it_returns_value_as_boolean(): void
+    {
+        factory(Config::class)->create([
+            'name'  => 'yunus.was.here',
+            'val'   => "1",
+        ]);
+
+        factory(Config::class)->create([
+            'name'  => 'foo.bar',
+            'val'   => "0",
+        ]);
+
+        $this->assertTrue($this->laravelConfig->getValueAsBoolean('yunus.was.here'));
+        $this->assertFalse($this->laravelConfig->getValueAsBoolean('foo.bar'));
+    }
+
+    /** @test */
+    public function it_returns_value_as_int(): void
+    {
+        factory(Config::class)->create([
+            'name'  => 'yunus.was.here',
+            'val'   => "123456",
+        ]);
+
+        $this->assertIsInt($this->laravelConfig->getValueAsInt('yunus.was.here'));
+    }
+
+    /** @test */
+    public function it_returns_value_as_decode_json(): void
+    {
+        factory(Config::class)->create([
+            'name'  => 'yunus.was.here',
+            'val'   => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}'
+        ]);
+
+        $response = $this->laravelConfig->getValueAsDecodeJson('yunus.was.here');
+
+        $this->assertIsArray($response);
+        $this->assertArrayHasKey('9', $response);
+        $this->assertArrayHasKey('2', $response);
+        $this->assertArrayHasKey('31', $response);
+    }
+
+    /** @test */
+    public function it_returns_value_as_date(): void
+    {
+        factory(Config::class)->create([
+            'name'  => 'yunus.was.here',
+            'val'   => '2024-02-28 17:00'
+        ]);
+
+        $response = $this->laravelConfig->getValueAsDate('yunus.was.here');
+
+        $this->assertInstanceOf(Carbon::class, $response);
     }
 }

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -33,9 +33,9 @@ class LaravelConfigTest extends TestCase
         $this->laravelConfig->create($configItem);
 
         $this->assertDatabaseHas(config('laravel-config.table'), [
-            'name'        => $configItem->name,
-            'val'         => $configItem->val,
-            'type'        => $configItem->type,
+            'name' => $configItem->name,
+            'val' => $configItem->val,
+            'type' => $configItem->type,
             'description' => $configItem->description,
         ]);
     }
@@ -54,9 +54,9 @@ class LaravelConfigTest extends TestCase
         $this->laravelConfig->create($configItem);
 
         $this->assertDatabaseHas(config('laravel-config.table'), [
-            'name'        => $configItem->name,
-            'val'         => $configItem->val,
-            'type'        => $configItem->type,
+            'name' => $configItem->name,
+            'val' => $configItem->val,
+            'type' => $configItem->type,
             'description' => $configItem->description,
         ]);
 
@@ -96,9 +96,9 @@ class LaravelConfigTest extends TestCase
         $this->laravelConfig->update($config, $configItem);
 
         $this->assertDatabaseHas(config('laravel-config.table'), [
-            'name'        => $config->name,
-            'val'         => $configItem->val,
-            'type'        => $configItem->type,
+            'name' => $config->name,
+            'val' => $configItem->val,
+            'type' => $configItem->type,
             'description' => $configItem->description,
         ]);
     }
@@ -193,12 +193,12 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'foo.bar',
-            'val'  => true,
+            'val' => true,
         ]);
 
         factory(Config::class)->create([
             'name' => 'foo.baz',
-            'val'  => false,
+            'val' => false,
         ]);
 
         $response = $this->laravelConfig->getNested('foo');
@@ -213,12 +213,12 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'yunus.was.here',
-            'val'  => "1",
+            'val' => '1',
         ]);
 
         factory(Config::class)->create([
             'name' => 'foo.bar',
-            'val'  => "0",
+            'val' => '0',
         ]);
 
         $this->assertTrue($this->laravelConfig->getValueAsBoolean('yunus.was.here'));
@@ -230,7 +230,7 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'yunus.was.here',
-            'val'  => "123456",
+            'val' => '123456',
         ]);
 
         $this->assertIsInt($this->laravelConfig->getValueAsInt('yunus.was.here'));
@@ -241,7 +241,7 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'yunus.was.here',
-            'val'  => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}'
+            'val' => '{"9":[7,8,9],"2":[7,8,9],"31":[10,11,12]}'
         ]);
 
         $response = $this->laravelConfig->getValueAsDecodeJson('yunus.was.here');
@@ -257,7 +257,7 @@ class LaravelConfigTest extends TestCase
     {
         factory(Config::class)->create([
             'name' => 'yunus.was.here',
-            'val'  => '2024-02-28 17:00'
+            'val' => '2024-02-28 17:00'
         ]);
 
         $response = $this->laravelConfig->getValueAsDate('yunus.was.here');


### PR DESCRIPTION
This pull request introduces new methods and corresponding tests to the `LaravelConfig` class. The new methods provide utility for retrieving configuration values of specific types, enhancing flexibility for developers.

Added Methods:

- `getValueAsBoolean`: Retrieves the value of the specified configuration key as a boolean.
- `getValueAsInt`: Retrieves the value of the specified configuration key as an integer.
- `getValueAsDecodeJson`: Retrieves the value of the specified configuration key and decodes it from JSON to an array or an object.
- `getValueAsDate`: Retrieves the value of the specified configuration key and converts it to a Carbon Date instance.