### PR TITLE
Update type column in config table

### DIFF
--- a/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
+++ b/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
@@ -14,7 +14,7 @@ class UpdateTypeColumnInConfigTable extends Migration
     public function up(): void
     {
         Schema::table(config('laravel-config.table'), function (Blueprint $table) {
-            $table->string('type')->default('boolean')->change();
+            $table->string('type')->nullable(false)->default('boolean')->change();
         });
     }
 
@@ -26,7 +26,7 @@ class UpdateTypeColumnInConfigTable extends Migration
     public function down(): void
     {
         Schema::table(config('laravel-config.table'), function (Blueprint $table) {
-            $table->enum('type', ['boolean', 'text'])->default('boolean')->change();
+            $table->enum('type', ['boolean', 'text'])->nullable()->default('boolean')->change();
         });
     }
 }


### PR DESCRIPTION
This commit modifies the 'type' column in the configuration table to disallow null values and sets the default value to 'boolean'. This change ensures data integrity and consistency in the application's configuration settings.