### PR TITLE
Update type column in config table

### DIFF
--- a/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
+++ b/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
@@ -14,20 +14,21 @@ class UpdateTypeColumnInConfigTable extends Migration
      */
     public function up(): void
     {
-        Schema::table(config('laravel-config.table'), function (Blueprint $table) {
-            DB::statement("ALTER TABLE laravel_config CHANGE type type varchar(255) DEFAULT 'boolean' NOT NULL");
-        });
+        $tableName = config('laravel-config.table');
+
+        Schema::table($tableName, function () use($tableName): void {
+            DB::statement("ALTER TABLE $tableName CHANGE type type varchar(255) DEFAULT 'boolean' NOT NULL");        });
     }
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
     public function down(): void
     {
-        Schema::table(config('laravel-config.table'), function (Blueprint $table) {
-            DB::statement("ALTER TABLE laravel_config CHANGE type type ENUM('boolean','text') DEFAULT 'boolean' NOT NULL ");
+        $tableName = config('laravel-config.table');
+
+        Schema::table($tableName, function () use($tableName): void {
+            DB::statement("ALTER TABLE $tableName CHANGE type type ENUM('boolean','text') DEFAULT 'boolean' NOT NULL ");
         });
     }
 }

--- a/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
+++ b/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class UpdateTypeColumnInConfigTable extends Migration
@@ -14,7 +15,7 @@ class UpdateTypeColumnInConfigTable extends Migration
     public function up(): void
     {
         Schema::table(config('laravel-config.table'), function (Blueprint $table) {
-            $table->string('type')->nullable(false)->default('boolean')->change();
+            DB::statement("ALTER TABLE laravel_config CHANGE type type varchar(255) DEFAULT 'boolean' NOT NULL");
         });
     }
 
@@ -26,7 +27,7 @@ class UpdateTypeColumnInConfigTable extends Migration
     public function down(): void
     {
         Schema::table(config('laravel-config.table'), function (Blueprint $table) {
-            $table->enum('type', ['boolean', 'text'])->nullable()->default('boolean')->change();
+            DB::statement("ALTER TABLE laravel_config CHANGE type type ENUM('boolean','text') DEFAULT 'boolean' NOT NULL ");
         });
     }
 }

--- a/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
+++ b/database/migrations/2024_02_29_111020_update_type_column_in_config_table.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -16,8 +15,9 @@ class UpdateTypeColumnInConfigTable extends Migration
     {
         $tableName = config('laravel-config.table');
 
-        Schema::table($tableName, function () use($tableName): void {
-            DB::statement("ALTER TABLE $tableName CHANGE type type varchar(255) DEFAULT 'boolean' NOT NULL");        });
+        Schema::table($tableName, function () use ($tableName): void {
+            DB::statement("ALTER TABLE $tableName CHANGE type type varchar(255) DEFAULT 'boolean' NOT NULL");
+        });
     }
 
     /**
@@ -27,7 +27,7 @@ class UpdateTypeColumnInConfigTable extends Migration
     {
         $tableName = config('laravel-config.table');
 
-        Schema::table($tableName, function () use($tableName): void {
+        Schema::table($tableName, function () use ($tableName): void {
             DB::statement("ALTER TABLE $tableName CHANGE type type ENUM('boolean','text') DEFAULT 'boolean' NOT NULL ");
         });
     }


### PR DESCRIPTION
To change a column type from enum to string in a Laravel migration, you need to use the change() method provided by the doctrine/dbal package. However, there is a known limitation with the change() method when it comes to altering enum columns because enum is a non-standard type in MySQL and is not fully supported by the Doctrine DBAL library.

I manually specified SQL to change the column type in migration. 