### PR TITLE
Models and Traits Publishable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to `laravel-config` will be documented in this file.
 - Because of the Braking Changes I also added a `get_config`, `set_config`, `has_config`, and `create_config` aliases for consistency
 - NON Braking Change: Removed the `all` function as it's not needed anymore since it's a function of a Model
 - I'm adding more functions to another Trait that can be added by including it in the Model these are all traits that I've found useful
+- Added comands to `get_config` and `set_config` from the console
+- Added more datatypes
+
 
 ## [5.1.0] - 2024-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to `laravel-config` will be documented in this file.
 
 ## [Unreleased]
 
+## [5.1.1-EPF] -2024-04-09
+
+- ### Braking Change: Made the Models and Traits Publishable, so you can add SoftDeletes, auditing, and/or caching if you want (YOU MUST RUN THE INSTALLATION COMMAND)
+- ### Braking Change: Check your Namespaces 
+- Moved the config functions to a Trait so adding functions is as simple as editing the published Trait or adding another Trait
+- I left the original `LaravelConfig` class as an alies of the Model, but it needs more testing
+- ### Braking Change: The Update function needed to be renamed from `update` to `update_config`
+- ### Braking Change: The Update function Only takes one parameter just the `ConfigItem`
+- ### Braking Change: The `update_config` helper Only takes one parameter just the `ConfigItem`
+- ### Braking Change: The Delete function needed to be renamed from `delete` to `delete_config`
+- Because of the Braking Changes I also added a `get_config`, `set_config`, `has_config`, and `create_config` aliases for consistency
+- NON Braking Change: Removed the `all` function as it's not needed anymore since it's a function of a Model
+- I'm adding more functions to another Trait that can be added by including it in the Model these are all traits that I've found useful
+
 ## [5.1.0] - 2024-04-08
 
 - Laravel 11 and PHP 8.3 support added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 All notable changes to `laravel-config` will be documented in this file.
 
-## [Unreleased]
-
-## [5.1.1-EPF] -2024-04-09
+## [Unreleased] - 2024-04-09
 
 - ### Braking Change: Made the Models and Traits Publishable, so you can add SoftDeletes, auditing, and/or caching if you want (YOU MUST RUN THE INSTALLATION COMMAND)
 - ### Braking Change: Check your Namespaces 

--- a/README.md
+++ b/README.md
@@ -16,21 +16,27 @@ You can install the package via composer:
 ```bash
 composer require tarfin-labs/laravel-config
 ```
+Next, you MUST publish Models, Factories, and Traits 
+When updating you might need to rerun the installation command be warned this will overwrite any changes made to any of the published Models, Factories, and Traits
+
+```bash
+php artisan laravel-config:install
+```
 Next, you should publish the Laravel config migration file using the vendor:publish Artisan command.
 
-```
+```bash
 php artisan vendor:publish --provider="TarfinLabs\LaravelConfig\LaravelConfigServiceProvider" --tag="laravel-config"
 ```
 
 If you want to use Laravel Config database factory, you can publish it too, using the command:
 
-```
+```bash
 php artisan vendor:publish --provider="TarfinLabs\LaravelConfig\LaravelConfigServiceProvider" --tag="laravel-config-factories"
 ```
 
 Finally, you should run your database migrations:
 
-```
+```bash
 php artisan migrate
 ```
 
@@ -40,7 +46,7 @@ Simple usage example of laravel-config package in your Laravel app.
 
 Create new config parameter:
 
-``` php
+```php
 $factory = new ConfigFactory();
 $configItem = $factory->setName('key')
     ->setType(ConfigDataType::BOOLEAN)
@@ -54,37 +60,37 @@ LaravelConfig::create($configItem);
 
 Get value with config name:
 
-``` php
+```php
 LaravelConfig::get('key');
 ```
 
 Set value with config name and value:
 
-``` php
+```php
 LaravelConfig::set('key', 'value');
 ```
 
 Get all config parameters:
 
-``` php
+```php
 LaravelConfig::all();
 ```
 
 Get config items by tag:
 
-``` php
+```php
 LaravelConfig::getByTag('key');
 ```
 
 Check if the config exists:
 
-``` php
+```php
 LaravelConfig::has('key');
 ```
 
 Update config with new values:
 
-``` php
+```php
 $factory = new ConfigFactory($configId);
 $configItem = $factory->setName('updated-key')
     ->setType(ConfigDataType::BOOLEAN)
@@ -93,13 +99,13 @@ $configItem = $factory->setName('updated-key')
     ->setDescription('updated description')
     ->get();
 
-LaravelConfig::update($configItem);
+LaravelConfig::update_config($configItem);
 ```
 
 Remove config:
 
-``` php
-LaravelConfig::delete('key');
+```php
+LaravelConfig::delete_config('key');
 ```
 
 ### Nested Parameters
@@ -141,7 +147,7 @@ LaravelConfig::getNested('foo');
 ### Helpers
 You can also use helper functions:
 
-``` php
+```php
 // Creating config item
 $factory = new ConfigFactory();
 $configItem = $factory->setName('key')
@@ -182,7 +188,7 @@ read_nested('foo.bar');
 
 ### Testing
 
-``` bash
+```bash
 composer test
 ```
 

--- a/config/config.php
+++ b/config/config.php
@@ -1,8 +1,5 @@
 <?php
 
-/*
- * You can place your custom package configuration in here.
- */
 return [
     'table' => env('LARAVEL_CONFIG_TABLE', 'laravel_config'),
 ];

--- a/database/factories/ConfigFactory.php
+++ b/database/factories/ConfigFactory.php
@@ -1,9 +1,9 @@
 <?php
 
-use Faker\Generator as Faker;
-// use Illuminate\Database\Eloquent\Factory;
-use Illuminate\Support\Carbon;
 use App\Models\Config as ConfigModel;
+// use Illuminate\Database\Eloquent\Factory;
+use Faker\Generator as Faker;
+use Illuminate\Support\Carbon;
 
 /* @var $factory Factory */
 

--- a/database/factories/ConfigFactory.php
+++ b/database/factories/ConfigFactory.php
@@ -1,13 +1,13 @@
 <?php
 
 use Faker\Generator as Faker;
-use Illuminate\Database\Eloquent\Factory;
+// use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Support\Carbon;
-use TarfinLabs\LaravelConfig\Config\Config;
+use App\Models\Config as ConfigModel;
 
 /* @var $factory Factory */
 
-$factory->define(Config::class, function (Faker $faker, array $attributes = []) {
+$factory->define(ConfigModel::class, function (Faker $faker, array $attributes = []) {
     return [
         'name' => $attributes['name'] ?? $faker->word().$faker->asciify('*****'),
         'type' => $attributes['type'] ?? $faker->randomElement(['boolean', 'text']),

--- a/src/Casts/ConfigValueCast.php
+++ b/src/Casts/ConfigValueCast.php
@@ -4,12 +4,20 @@ namespace TarfinLabs\LaravelConfig\Casts;
 
 use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Database\Eloquent\Model;
 use TarfinLabs\LaravelConfig\Enums\ConfigDataType;
 
 class ConfigValueCast implements CastsAttributes
 {
-    public function get(Model $model, string $key, mixed $value, array $attributes)
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return TGet|null
+     */
+    public function get($model, string $key, mixed $value, array $attributes)
     {
         return match ($attributes['type']) {
             ConfigDataType::BOOLEAN->value => (bool) $value,
@@ -21,7 +29,16 @@ class ConfigValueCast implements CastsAttributes
         };
     }
 
-    public function set(Model $model, string $key, mixed $value, array $attributes)
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  TSet|null  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, mixed $value, array $attributes)
     {
         return $value;
     }

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -2,19 +2,22 @@
 
 namespace TarfinLabs\LaravelConfig\Config;
 
+use App\Models\Config as ConfigModel;
+use TarfinLabs\LaravelConfig\Config\ConfigItem;
+
 class ConfigFactory
 {
     /**
      * @var ConfigItem
      */
-    protected $configItem;
+    protected ConfigItem $configItem;
 
     /**
      * ConfigFactory constructor.
      *
-     * @param  Config|null  $config
+     * @param  ConfigModel|null  $config
      */
-    public function __construct(Config $config = null)
+    public function __construct(ConfigModel $config = null)
     {
         $this->configItem = new ConfigItem();
 

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -3,7 +3,6 @@
 namespace TarfinLabs\LaravelConfig\Config;
 
 use App\Models\Config as ConfigModel;
-use TarfinLabs\LaravelConfig\Config\ConfigItem;
 
 class ConfigFactory
 {

--- a/src/Console/GetCommand.php
+++ b/src/Console/GetCommand.php
@@ -20,6 +20,6 @@ class GetCommand extends Command
     public function handle()
     {
         $value = LaravelConfig::get_config($this->argument('key'));
-        $this->line(print_r($value, true));
+        $this->line($value);
     }
 }

--- a/src/Console/GetCommand.php
+++ b/src/Console/GetCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TarfinLabs\LaravelConfig\Console;
+
+use Illuminate\Console\Command;
+use TarfinLabs\LaravelConfig\LaravelConfigFacade as LaravelConfig;
+
+class GetCommand extends Command
+{
+    protected $signature = 'laravel-config:get 
+                            {key        : Key }';
+
+    protected $description = 'Get a key from the database and dump it to stdout';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $value = LaravelConfig::get_config($this->argument('key'));
+        $this->line(print_r($value, true));
+    }
+}

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -42,5 +42,4 @@ class InstallCommand extends Command
 
         $this->info('Laravel-config installed successfully.');
     }
-
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace TarfinLabs\LaravelConfig\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class InstallCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'laravel-config:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install the Laravel-config Models, Factories, and Traits.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Models...
+        (new Filesystem)->ensureDirectoryExists(app_path('Models/'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../Models', app_path('Models/'));
+
+        // Traits...
+        (new Filesystem)->ensureDirectoryExists(app_path('Traits/'));
+        (new Filesystem)->copyDirectory(__DIR__.'/../Traits', app_path('Traits/'));
+
+        // Factory...
+        (new Filesystem)->ensureDirectoryExists(database_path('factories/'));
+        (new Filesystem)->copy(__DIR__.'/../../database/factories/ConfigFactory.php', database_path('factories/ConfigFactory.php'));
+
+        $this->info('Laravel-config installed successfully.');
+    }
+
+}

--- a/src/Console/SetCommand.php
+++ b/src/Console/SetCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TarfinLabs\LaravelConfig\Console;
+
+use Illuminate\Console\Command;
+use TarfinLabs\LaravelConfig\LaravelConfigFacade as LaravelConfig;
+
+class SetCommand extends Command
+{
+    protected $signature = 'laravel-config:set 
+                            {key        : Key }
+                            {value      : A string value }';
+
+    protected $description = 'Save a key to the database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        LaravelConfig::set_config($this->argument('key'), $this->argument('value'));
+    }
+}

--- a/src/Console/SetCommand.php
+++ b/src/Console/SetCommand.php
@@ -20,7 +20,6 @@ class SetCommand extends Command
      */
     public function handle()
     {
-
         LaravelConfig::set_config($this->argument('key'), $this->argument('value'));
     }
 }

--- a/src/Enums/ConfigDataType.php
+++ b/src/Enums/ConfigDataType.php
@@ -4,6 +4,9 @@ namespace TarfinLabs\LaravelConfig\Enums;
 
 enum ConfigDataType: string
 {
+    case STRING = 'string';
+    case NUMERIC = 'numeric';
+    case NONE = 'None';
     case INTEGER = 'integer';
     case BOOLEAN = 'boolean';
     case JSON = 'json';

--- a/src/LaravelConfig.php
+++ b/src/LaravelConfig.php
@@ -3,8 +3,8 @@
 namespace TarfinLabs\LaravelConfig;
 
 use Illuminate\Support\Collection;
-use TarfinLabs\LaravelConfig\LaravelConfigFacade as ConfigFacade;
 use TarfinLabs\LaravelConfig\Config\ConfigItem;
+use TarfinLabs\LaravelConfig\LaravelConfigFacade as ConfigFacade;
 
 class LaravelConfig
 {
@@ -17,7 +17,7 @@ class LaravelConfig
      */
     public function get(string $name, $default = null): mixed
     {
-        if (!$this->has($name)) {
+        if (! $this->has($name)) {
             return $default;
         }
 
@@ -96,7 +96,8 @@ class LaravelConfig
         if ($this->has($configItem->name)) {
             return false;
         }
-        return ConfigFacade::create( $configItem);
+
+        return ConfigFacade::create($configItem);
     }
 
     /**

--- a/src/LaravelConfigServiceProvider.php
+++ b/src/LaravelConfigServiceProvider.php
@@ -28,6 +28,8 @@ class LaravelConfigServiceProvider extends ServiceProvider
             ], 'laravel-config-models');
             $this->commands([
                 Console\InstallCommand::class,
+                Console\SetCommand::class,
+                Console\GetCommand::class,
             ]);
         }
     }

--- a/src/LaravelConfigServiceProvider.php
+++ b/src/LaravelConfigServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace TarfinLabs\LaravelConfig;
 
-use Illuminate\Support\ServiceProvider;
 use App\Models\Config as ConfigModel;
+use Illuminate\Support\ServiceProvider;
 
 class LaravelConfigServiceProvider extends ServiceProvider
 {
@@ -12,11 +12,9 @@ class LaravelConfigServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
         if ($this->app->runningInConsole()) {
-
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('laravel-config.php'),
             ], 'laravel-config');

--- a/src/LaravelConfigServiceProvider.php
+++ b/src/LaravelConfigServiceProvider.php
@@ -3,6 +3,7 @@
 namespace TarfinLabs\LaravelConfig;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\Config as ConfigModel;
 
 class LaravelConfigServiceProvider extends ServiceProvider
 {
@@ -11,12 +12,11 @@ class LaravelConfigServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        /*
-         * Optional methods to load your package assets
-         */
+
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
         if ($this->app->runningInConsole()) {
+
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('laravel-config.php'),
             ], 'laravel-config');
@@ -24,6 +24,13 @@ class LaravelConfigServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../database/factories/ConfigFactory.php' => database_path('factories/ConfigFactory.php'),
             ], 'laravel-config-factories');
+            $this->publishes([
+                __DIR__.'/Traits' => app_path('Traits'),
+                __DIR__.'/Models' => app_path('Models'),
+            ], 'laravel-config-models');
+            $this->commands([
+                Console\InstallCommand::class,
+            ]);
         }
     }
 
@@ -36,8 +43,8 @@ class LaravelConfigServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'laravel-config');
 
         // Register the main class to use with the facade
-        $this->app->singleton('laravel-config', function () {
-            return new LaravelConfig;
+        $this->app->singleton('laravel-config', static function () {
+            return new ConfigModel();
         });
     }
 }

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -1,12 +1,15 @@
 <?php
 
-namespace TarfinLabs\LaravelConfig\Config;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Traits\LaravelConfigTrait;
 use TarfinLabs\LaravelConfig\Casts\ConfigValueCast;
 
 class Config extends Model
 {
+    use LaravelConfigTrait;
+
     protected $table = 'config';
 
     protected $guarded = [];

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use App\Traits\LaravelConfigTrait;
+use Illuminate\Database\Eloquent\Model;
 use TarfinLabs\LaravelConfig\Casts\ConfigValueCast;
 
 class Config extends Model

--- a/src/Traits/LaravelConfigDataByIdTrait.php
+++ b/src/Traits/LaravelConfigDataByIdTrait.php
@@ -2,20 +2,17 @@
 
 namespace App\Traits;
 
-
 trait LaravelConfigDataByIdTrait
 {
     /**
      * Set config with given data by id.
      *
      * @param  int  $id
-     * @param  mixed $value
+     * @param  mixed  $value
      * @return mixed
      */
     public function set_by_id(int $id, mixed $value): mixed
     {
-
-
         $config = parent::where('id', $id)->first();
 
         if ($config === null) {
@@ -31,15 +28,12 @@ trait LaravelConfigDataByIdTrait
     /**
      * Set config discription with given data by id.
      *
-     * @param int $id
-     * @param string $value
+     * @param  int  $id
+     * @param  string  $value
      * @return string|null
      */
-
     public function set_discription_by_id(int $id, string $value): string|null
     {
-
-
         $config = parent::where('id', $id)->first();
 
         if ($config === null) {
@@ -51,11 +45,12 @@ trait LaravelConfigDataByIdTrait
 
         return $value;
     }
+
     /**
      * Set config description with given data by id.
      *
      * @param  int  $id
-     * @param mixed $value
+     * @param  mixed  $value
      * @return array|null
      */
     public function set_tags_by_id(int $id, mixed $value): mixed
@@ -72,12 +67,11 @@ trait LaravelConfigDataByIdTrait
         return $value;
     }
 
-
     /**
      * Get config by given id.
      *
-     * @param int $id
-     * @param mixed $default
+     * @param  int  $id
+     * @param  mixed  $default
      * @return mixed
      */
     public function get_by_id(int $id, mixed $default = null): mixed
@@ -90,5 +84,4 @@ trait LaravelConfigDataByIdTrait
 
         return $config;
     }
-
 }

--- a/src/Traits/LaravelConfigDataByIdTrait.php
+++ b/src/Traits/LaravelConfigDataByIdTrait.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Traits;
+
+
+trait LaravelConfigDataByIdTrait
+{
+    /**
+     * Set config with given data by id.
+     *
+     * @param  int  $id
+     * @param  mixed $value
+     * @return mixed
+     */
+    public function set_by_id(int $id, mixed $value): mixed
+    {
+
+
+        $config = parent::where('id', $id)->first();
+
+        if ($config === null) {
+            return null;
+        }
+
+        $config->val = $value;
+        $config->save();
+
+        return $value;
+    }
+
+    /**
+     * Set config discription with given data by id.
+     *
+     * @param int $id
+     * @param string $value
+     * @return string|null
+     */
+
+    public function set_discription_by_id(int $id, string $value): string|null
+    {
+
+
+        $config = parent::where('id', $id)->first();
+
+        if ($config === null) {
+            return null;
+        }
+
+        $config->description = $value;
+        $config->save();
+
+        return $value;
+    }
+    /**
+     * Set config description with given data by id.
+     *
+     * @param  int  $id
+     * @param mixed $value
+     * @return array|null
+     */
+    public function set_tags_by_id(int $id, mixed $value): mixed
+    {
+        $config = parent::where('id', $id)->first();
+
+        if ($config === null) {
+            return null;
+        }
+
+        $config->tags = $value;
+        $config->save();
+
+        return $value;
+    }
+
+
+    /**
+     * Get config by given id.
+     *
+     * @param int $id
+     * @param mixed $default
+     * @return mixed
+     */
+    public function get_by_id(int $id, mixed $default = null): mixed
+    {
+        $config = parent::where('id', $id)->first();
+
+        if ($config === null) {
+            return $default;
+        }
+
+        return $config;
+    }
+
+}

--- a/src/Traits/LaravelConfigTrait.php
+++ b/src/Traits/LaravelConfigTrait.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Collection;
+use TarfinLabs\LaravelConfig\Config\ConfigItem;
+
+trait LaravelConfigTrait
+{
+
+    /**
+     * Get config by given name.
+     *
+     * @param  string  $name
+     * @param  $default
+     * @return mixed
+     */
+    public function get(string $name, $default = null): mixed
+    {
+
+        if (! $this->has($name)) {
+            return $default;
+        }
+
+        $config = parent::where('name', $name)->first();
+
+        return $config->val;
+    }
+    /**
+     * Get config by given name.
+     * this is an alias of the get function
+     * for consistency
+     *
+     * @param  string  $name
+     * @param  $default
+     * @return mixed
+     */
+    public function get_config(string $name, $default = null): mixed
+    {
+        return $this->get($name, $default);
+    }
+
+    /**
+     * Get nested config params.
+     *
+     * @param  string  $namespace
+     * @return Collection
+     */
+    public function getNested(string $namespace): Collection
+    {
+        $params = parent::where('name', 'LIKE', "{$namespace}.%")->get();
+
+        $config = collect();
+
+        foreach ($params as $param) {
+            $keys = explode('.', str_replace("{$namespace}.", '', $param->name));
+            $name = '';
+
+            foreach ($keys as $key) {
+                $name .= $key.'.';
+            }
+
+            $param->name = rtrim($name, '.');
+
+            $config->push($param);
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param  $tags
+     * @return Collection
+     */
+    public function getByTag($tags): Collection|null
+    {
+        if (! is_array($tags)) {
+            $tags = [$tags];
+        }
+
+        return parent::whereJsonContains('tags', $tags)->get();
+    }
+
+    /**
+     * Set config with given data.
+     *
+     * @param  string  $name
+     * @param  $value
+     * @return mixed
+     */
+    public function set(string $name, $value): mixed
+    {
+        if (! $this->has($name)) {
+            return null;
+        }
+
+        $config = parent::where('name', $name)->first();
+
+        $config->val = $value;
+        $config->save();
+
+        return $value;
+    }
+
+
+    /**
+     * Set config with given data.
+     * this is an alias of the set function
+     * for consistency
+     * @param  string  $name
+     * @param  $value
+     * @return mixed
+     */
+    public function set_config(string $name, $value): mixed
+    {
+        return $this->set($name, $value);
+    }
+
+
+    /**
+     * Check whether a config parameter is set.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function has(string $name): bool
+    {
+        return parent::where('name', $name)->count() > 0;
+    }
+
+    /**
+     * Check whether a config parameter is set.
+     * this is an alias of the has function
+     * for consistency
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function has_config(string $name): bool
+    {
+        return $this->has($name);
+    }
+
+
+    /**
+     * Create a new config parameter.
+     *
+     * @param  ConfigItem  $configItem
+     * @return bool
+     */
+    public function create(ConfigItem $configItem): bool
+    {
+        if ($this->has($configItem->name)) {
+            return false;
+        }
+
+        return $this->fillColumns($configItem)->save();
+    }
+
+    /**
+     * Create a new config parameter.
+     * this is an alias of the create function
+     * for consistency
+     *
+     * @param  ConfigItem  $configItem
+     * @return bool
+     */
+    public function create_config(ConfigItem $configItem): bool
+    {
+        return $this->create($configItem);
+    }
+
+    /**
+     * Update config paremeter.
+     *
+     * @param  ConfigItem  $configItem
+     * @return mixed
+     */
+    public function update_config(ConfigItem $configItem): mixed
+    {
+        $config = parent::where('name', $configItem->name)->first();
+
+        return $config->fillColumns($configItem)->save();
+    }
+
+    /**
+     * Delete config parameter.
+     *
+     * @param  Config  $config
+     * @return int
+     */
+    public function delete_config(parent $config): int
+    {
+        return parent::destroy($config->id);
+    }
+
+    /**
+     * Fill config paremeter columns.
+     *
+     * @param  Config  $config
+     * @param  ConfigItem  $configItem
+     * @return parent
+     */
+    private function fillColumns(ConfigItem $configItem): parent
+    {
+        $this->name = $configItem->name;
+        $this->val = $configItem->val;
+        $this->type = $configItem->type;
+        $this->description = $configItem->description;
+        $this->tags = $configItem->tags;
+
+        return $this;
+    }
+}

--- a/src/Traits/LaravelConfigTrait.php
+++ b/src/Traits/LaravelConfigTrait.php
@@ -7,7 +7,6 @@ use TarfinLabs\LaravelConfig\Config\ConfigItem;
 
 trait LaravelConfigTrait
 {
-
     /**
      * Get config by given name.
      *
@@ -17,7 +16,6 @@ trait LaravelConfigTrait
      */
     public function get(string $name, $default = null): mixed
     {
-
         if (! $this->has($name)) {
             return $default;
         }
@@ -26,10 +24,11 @@ trait LaravelConfigTrait
 
         return $config->val;
     }
+
     /**
      * Get config by given name.
      * this is an alias of the get function
-     * for consistency
+     * for consistency.
      *
      * @param  string  $name
      * @param  $default
@@ -102,11 +101,11 @@ trait LaravelConfigTrait
         return $value;
     }
 
-
     /**
      * Set config with given data.
      * this is an alias of the set function
-     * for consistency
+     * for consistency.
+     *
      * @param  string  $name
      * @param  $value
      * @return mixed
@@ -115,7 +114,6 @@ trait LaravelConfigTrait
     {
         return $this->set($name, $value);
     }
-
 
     /**
      * Check whether a config parameter is set.
@@ -131,7 +129,7 @@ trait LaravelConfigTrait
     /**
      * Check whether a config parameter is set.
      * this is an alias of the has function
-     * for consistency
+     * for consistency.
      *
      * @param  string  $name
      * @return bool
@@ -140,7 +138,6 @@ trait LaravelConfigTrait
     {
         return $this->has($name);
     }
-
 
     /**
      * Create a new config parameter.
@@ -160,7 +157,7 @@ trait LaravelConfigTrait
     /**
      * Create a new config parameter.
      * this is an alias of the create function
-     * for consistency
+     * for consistency.
      *
      * @param  ConfigItem  $configItem
      * @return bool

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-use TarfinLabs\LaravelConfig\Config\Config;
+use App\Models\Config as ConfigModel;
 use TarfinLabs\LaravelConfig\Config\ConfigItem;
 
 if (! function_exists('create_config')) {
@@ -10,7 +10,7 @@ if (! function_exists('create_config')) {
      * @param  ConfigItem  $configItem
      * @return mixed
      */
-    function create_config(ConfigItem $configItem)
+    function create_config(ConfigItem $configItem): mixed
     {
         return app('laravel-config')->create($configItem);
     }
@@ -23,9 +23,9 @@ if (! function_exists('read_config')) {
      * @param  string|null  $key
      * @return mixed
      */
-    function read_config(string $key = null)
+    function read_config(string|null $key = null): mixed
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return app('laravel-config')->all();
         }
 
@@ -40,7 +40,7 @@ if (! function_exists('read_nested')) {
      * @param  string|null  $key
      * @return mixed
      */
-    function read_nested(string $key)
+    function read_nested(string $key): mixed
     {
         return app('laravel-config')->getNested($key);
     }
@@ -50,13 +50,12 @@ if (! function_exists('update_config')) {
     /**
      * Update given config item by given data.
      *
-     * @param  Config  $config
      * @param  ConfigItem  $configItem
      * @return mixed
      */
-    function update_config(Config $config, ConfigItem $configItem)
+    function update_config(ConfigItem $configItem): mixed
     {
-        return app('laravel-config')->update($config, $configItem);
+        return app('laravel-config')->update_config($configItem);
     }
 }
 
@@ -64,12 +63,12 @@ if (! function_exists('delete_config')) {
     /**
      * Delete given config item.
      *
-     * @param  Config  $config
+     * @param  ConfigModel  $config
      * @return mixed
      */
-    function delete_config(Config $config)
+    function delete_config(ConfigModel $config): mixed
     {
-        return app('laravel-config')->delete($config);
+        return app('laravel-config')->delete_config($config);
     }
 }
 
@@ -81,7 +80,7 @@ if (! function_exists('set_config_value')) {
      * @param  $value
      * @return mixed
      */
-    function set_config_value(string $key, $value)
+    function set_config_value(string $key, $value): mixed
     {
         return app('laravel-config')->set($key, $value);
     }
@@ -94,7 +93,7 @@ if (! function_exists('has_config')) {
      * @param  string  $key
      * @return bool
      */
-    function has_config(string $key)
+    function has_config(string $key): bool
     {
         return app('laravel-config')->has($key);
     }

--- a/tests/LaravelConfigOldTest.php
+++ b/tests/LaravelConfigOldTest.php
@@ -2,13 +2,9 @@
 
 namespace TarfinLabs\LaravelConfig\Tests;
 
-
-
-
-
+use App\Models\Config as ConfigModel;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
-use App\Models\Config as ConfigModel;
 use TarfinLabs\LaravelConfig\Config\ConfigFactory;
 use TarfinLabs\LaravelConfig\Enums\ConfigDataType;
 use TarfinLabs\LaravelConfig\LaravelConfig;

--- a/tests/LaravelConfigOldTest.php
+++ b/tests/LaravelConfigOldTest.php
@@ -2,23 +2,27 @@
 
 namespace TarfinLabs\LaravelConfig\Tests;
 
+
+
+
+
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use App\Models\Config as ConfigModel;
 use TarfinLabs\LaravelConfig\Config\ConfigFactory;
 use TarfinLabs\LaravelConfig\Enums\ConfigDataType;
+use TarfinLabs\LaravelConfig\LaravelConfig;
 
-
-class LaravelConfigTest extends TestCase
+class LaravelConfigOldTest extends TestCase
 {
-    /** @var ConfigModel */
+    /** @var LaravelConfig */
     protected $laravelConfig;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->laravelConfig = new ConfigModel();
+        $this->laravelConfig = new LaravelConfig();
     }
 
     /** @test */
@@ -94,7 +98,7 @@ class LaravelConfigTest extends TestCase
                               ->setDescription('updated-description')
                               ->get();
 
-        $this->laravelConfig->update_config($configItem);
+        $this->laravelConfig->update($config, $configItem);
 
         $this->assertDatabaseHas(config('laravel-config.table'), [
             'name' => $config->name,
@@ -111,7 +115,7 @@ class LaravelConfigTest extends TestCase
         $config = factory(ConfigModel::class)->create(['name' => $name]);
         $this->assertDatabaseHas(config('laravel-config.table'), ['name' => $config->name]);
 
-        $this->laravelConfig->delete_config($config);
+        $this->laravelConfig->delete($config);
 
         $this->assertDatabaseMissing(config('laravel-config.table'), ['name' => $name]);
     }

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -2,12 +2,11 @@
 
 namespace TarfinLabs\LaravelConfig\Tests;
 
+use App\Models\Config as ConfigModel;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
-use App\Models\Config as ConfigModel;
 use TarfinLabs\LaravelConfig\Config\ConfigFactory;
 use TarfinLabs\LaravelConfig\Enums\ConfigDataType;
-
 
 class LaravelConfigTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,23 +2,29 @@
 
 namespace TarfinLabs\LaravelConfig\Tests;
 
-use Illuminate\Support\Facades\Schema;
+// use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use TarfinLabs\LaravelConfig\LaravelConfigServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
+    use RefreshDatabase;
+
     public function setUp(): void
     {
         parent::setUp();
 
         $this->withFactories(__DIR__.'/../database/factories');
 
-        Schema::dropAllTables();
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
-        $this->artisan('migrate', [
-            '--database' => 'mysql',
-            '--realpath' => realpath(__DIR__.'/../database/migrations'),
-        ]);
+        // Schema::dropAllTables();
+
+        // $this->artisan('migrate', [
+        //     '--database' => 'mysql',
+        //     '--realpath' => realpath(__DIR__.'/../database/migrations'),
+        // ]);
+        $this->artisan('laravel-config:install');
     }
 
     /**


### PR DESCRIPTION
- ### Braking Change: Made the Models and Traits Publishable, so you can add SoftDeletes, auditing, and/or caching if you want (YOU MUST RUN THE INSTALLATION COMMAND)
- ### Braking Change: Check your Namespaces 
- Moved the config functions to a Trait so adding functions is as simple as editing the published Trait or adding another Trait
- I left the original `LaravelConfig` class as an alies of the Model, but it needs more testing
- ### Braking Change: The Update function needed to be renamed from `update` to `update_config`
- ### Braking Change: The Update function Only takes one parameter just the `ConfigItem`
- ### Braking Change: The `update_config` helper Only takes one parameter just the `ConfigItem`
- ### Braking Change: The Delete function needed to be renamed from `delete` to `delete_config`
- Because of the Braking Changes I also added a `get_config`, `set_config`, `has_config`, and `create_config` aliases for consistency
- NON Braking Change: Removed the `all` function as it's not needed anymore since it's a function of a Model
- I'm adding more functions to another Trait that can be added by including it in the Model these are all traits that I've found useful


This fixes #38 and #37 