### PR TITLE
PHP 8.4 deprecation warning

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -23,7 +23,7 @@ if (! function_exists('read_config')) {
      * @param  string|null  $key
      * @return mixed
      */
-    function read_config(string $key = null)
+    function read_config(?string $key = null)
     {
         if (is_null($key)) {
             return app('laravel-config')->all();


### PR DESCRIPTION
Fix PHP 8.4 deprecated warning:

`Deprecated: read_config(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /laravel-packages/laravel-config/src/helpers.php on line 26`