### PR TITLE
feat: add Laravel 13 support (v6.1.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.1, 8.2, 8.3, 8.4, 8.5]
-                laravel: [10, 11, 12]
+                laravel: [10, 11, 12, 13]
                 stability: [prefer-stable]
                 exclude:
                     # PHP 8.1 doesn't support Laravel 11+ (requires PHP 8.2+)
@@ -18,10 +18,15 @@ jobs:
                       laravel: 11
                     - php: 8.1
                       laravel: 12
+                    # PHP 8.1 and 8.2 don't support Laravel 13 (requires PHP 8.3+)
+                    - php: 8.1
+                      laravel: 13
+                    - php: 8.2
+                      laravel: 13
                     # PHP 8.4+ only with latest Laravel versions
                     - php: 8.4
                       laravel: 10
-                    # PHP 8.5 only with Laravel 12
+                    # PHP 8.5 only with Laravel 12+
                     - php: 8.5
                       laravel: 10
                     - php: 8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to `laravel-config` will be documented in this file.
 
 ## [Unreleased]
 
+## [6.1.0] - 2026-04-02
+- Laravel 13 support added.
+
 ## [6.0.0] - 2025-12-22
 
 ### Breaking Changes

--- a/composer.json
+++ b/composer.json
@@ -31,13 +31,13 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
+        "php": "^8.1",
         "ext-json": "*",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^10.0|^11.0|^12.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0|^13.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
## Summary                                                                                                               
                                         
  - Added `illuminate/support: ^13.0` to package requirements                                                              
  - Added `orchestra/testbench: ^11.0` and `phpunit/phpunit: ^13.0` to dev requirements
  - Simplified PHP constraint from explicit list to `^8.1`                                                                 
  - Added Laravel 13 to CI test matrix with correct PHP exclusions (8.1 and 8.2 excluded, as Laravel 13 requires PHP 8.3+) 
                                                                                                                           
  ## Compatibility                                                                                                         
                                                                                                                           
  | Laravel | PHP         |                                                                                                
  |---------|-------------|              
  | 10      | 8.1 – 8.3   |                                                                                                
  | 11      | 8.2 – 8.5   |                  
  | 12      | 8.2 – 8.5   |                                                                                                
  | 13      | 8.3 – 8.5   |
                                                                                                                           
  ## Checklist                               
                                                                                                                           
  - [x] `composer.json` updated              
  - [x] `CHANGELOG.md` updated (v6.1.0)  
  - [x] CI matrix updated
  - [x] Tests passing on CI